### PR TITLE
Update dfltExcludedFSTypes

### DIFF
--- a/df/plugin.go
+++ b/df/plugin.go
@@ -102,6 +102,8 @@ var (
 		"none",
 		"tmpfs",
 		"aufs",
+		"vboxsf",
+		"fuse.lxcfs",
 	}
 )
 


### PR DESCRIPTION
Add vboxsf and fuse.lxcfs to default exclude fs types.